### PR TITLE
Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Change Log
 	* All perl scripts now have `env perl` in shebang to increase portability
 	* Support for GRIDEngine `h_vmem` memory option, if requested in pipeline file or in command line
 	* Support for explicit GRIDEngine queue nomination on the command line
+        * --verbose mode which includes version information for bowtie1&2, STAR, samtools_sort, trim_galore, tophat and htseq-count in the report file and also prints the commands submitted to the cluster on-screen.
     * Added compatability with GRIDEngine `~/.sge_request files` (by ignoring them). Thanks to [@s-andrews](https://github.com/s-andrews)
     * New tophat module called `tophat` which introduces a workaround for buggy MAPQ reporting by tophat whilst keeping unique alignments. Thanks to [@FelixKrueger](https://github.com/FelixKrueger).
         * The previous tophat module is still available if you're not interested in MAPQ scores and would like slightly faster processing. This is now called `tophat_broken_MAPQ.cfmod`.

--- a/cf
+++ b/cf
@@ -51,7 +51,7 @@ my $cl_paired_end;
 my $cl_single_end;
 my $cl_no_fn_check;
 my $file_list;
-my $cl_params;
+my $cl_params = '';
 my $cl_email;
 my $cl_priority;
 my $cl_total_cores;
@@ -557,6 +557,10 @@ if ($cl_paired_end){
 } elsif ($cl_single_end){
 	$runfile .= "\@force_single_end\n";
 }
+if ($cl_verbose) {
+	$cl_params .= " report_v";
+}
+
 
 # Parse pipeline config file
 

--- a/modules/bowtie1.cfmod
+++ b/modules/bowtie1.cfmod
@@ -101,9 +101,18 @@ my ($se_files, $pe_files) = CF::Helpers::is_paired_end(\%config, @$files);
 # FastQ encoding type. Once found on one file will assume all others are the same
 my $encoding = 0;
 
+
 # Go through each single end files and run Bowtie
 if($se_files && scalar(@$se_files) > 0){
+	my $first = 1;
 	foreach my $file (@$se_files){
+		my $command = "";
+		if ($first and grep(/^report_v$/, @$parameters) > 0){
+		    # print version number etc if 1) first iteration and 2) if parameters contains "report_version"
+		    $command .= "bowtie --version\n";
+		    $command .= "echo ---------- Bowtie1 output follows ---------- \n";
+		    $first = 0;
+		}	
 		
 		# Figure out the encoding if we don't already know
 		if(!$encoding){
@@ -123,11 +132,11 @@ if($se_files && scalar(@$se_files) > 0){
 			$file = "-";
 		}
 		
-		my $command = "$gzip bowtie -p $cores -t -m 1 $enc --strata --best -S --chunkmbs 2048 ".$config{bowtie_path}." $file | samtools view -bS - > $output_fn";
+		$command .= "$gzip bowtie -p $cores -t -m 1 $enc --strata --best -S --chunkmbs 2048 ".$config{bowtie_path}." $file | samtools view -bS - > $output_fn";
 		if ($mirna) {
 		    $command = "$gzip bowtie -p $cores -t -n 0 -l 15 -e 99999 -k 200 $enc --best -S --chunkmbs 2048 ".$config{bowtie_path}." $file | samtools view -bS - > $output_fn"
 		}
-		warn "\n###CFCMD $command\n\n";
+		warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 		
 		if(!system ($command)){
 			# Bowtie worked - print out resulting filenames
@@ -146,9 +155,17 @@ if($se_files && scalar(@$se_files) > 0){
 
 # Go through the paired end files and run Bowtie
 if($pe_files && scalar(@$pe_files) > 0){
+	my $first = 1;
 	foreach my $files_ref (@$pe_files){
 		my @files = @$files_ref;
 		if(scalar(@files) == 2){
+			my $command = "";
+			    if ($first and grep(/^report_v$/, @$parameters) > 0){
+			    # print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+			    $command .= "bowtie --version\n";
+			    $command .= "echo ---------- Bowtie1 output follows ---------- \n";
+			    $first = 0;
+			}
 			
 			# Figure out the encoding if we don't already know
 			if(!$encoding){
@@ -170,12 +187,12 @@ if($pe_files && scalar(@$pe_files) > 0){
 			
 			my $output_fn = $files[0]."_bowtie.bam";
 			
-			my $command = "bowtie -p $cores -t -m 1 $enc --strata --best --maxins 700 -S --chunkmbs 2048 ".$config{bowtie_path}." -1 ".$files[0]." -2 ".$files[1]." | samtools view -bSh 2>/dev/null - > $output_fn";
+			$command .= "bowtie -p $cores -t -m 1 $enc --strata --best --maxins 700 -S --chunkmbs 2048 ".$config{bowtie_path}." -1 ".$files[0]." -2 ".$files[1]." | samtools view -bSh 2>/dev/null - > $output_fn";
 
 			if ($mirna) {
 			    $command = "bowtie -p $cores -t -n 0 -l 15 -e 99999 -k 200 $enc --best --maxins 700 -S --chunkmbs 2048 ".$config{bowtie_path}." -1 ".$files[0]." -2 ".$files[1]." | samtools view -bSh 2>/dev/null - > $output_fn";
 			}
-			warn "\n###CFCMD $command\n\n";
+			warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 			
 			if(!system ($command)){
 				# Bowtie worked - print out resulting filenames

--- a/modules/bowtie2.cfmod
+++ b/modules/bowtie2.cfmod
@@ -100,7 +100,15 @@ my $encoding = 0;
 
 # Go through each single end files and run Bowtie
 if($se_files && scalar(@$se_files) > 0){
+	my $first = 1;
 	foreach my $file (@$se_files){
+		my $command = "";
+		if ($first and grep(/^report_v$/, @$parameters) > 0){
+			# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+			$command .= "bowtie2 --version\n";
+			$command .= "echo ---------- Bowtie2 output follows ---------- \n";
+			$first = 0;
+		}
 		
 		# Figure out the encoding if we don't already know
 		if(!$encoding){
@@ -113,8 +121,8 @@ if($se_files && scalar(@$se_files) > 0){
 		
 		my $output_fn = $file."_bowtie2.bam";
 		
-		my $command = "bowtie2 -p $cores -t $enc -x ".$config{bowtie2_path}." -U $file | samtools view -bS - > $output_fn";
-		warn "\n###CFCMD $command\n\n";
+		$command .= "bowtie2 -p $cores -t $enc -x ".$config{bowtie2_path}." -U $file | samtools view -bS - > $output_fn";
+		warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 		
 		if(!system ($command)){
 			# Bowtie worked - print out resulting filenames
@@ -133,9 +141,17 @@ if($se_files && scalar(@$se_files) > 0){
 
 # Go through the paired end files and run Bowtie
 if($pe_files && scalar(@$pe_files) > 0){
+	my $first = 1;
 	foreach my $files_ref (@$pe_files){
 		my @files = @$files_ref;
 		if(scalar(@files) == 2){
+			my $command = "";
+			if ($first and grep(/^report_v$/, @$parameters) > 0){
+				# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+				$command .= "bowtie2 --version\n";
+				$command .= "echo ---------- Bowtie2 output follows ---------- \n";
+				$first = 0;
+			}
 			
 			# Figure out the encoding if we don't already know
 			if(!$encoding){
@@ -148,8 +164,8 @@ if($pe_files && scalar(@$pe_files) > 0){
 			
 			my $output_fn = $files[0]."_bowtie2.bam";
 			
-			my $command = "bowtie2 -p $cores -t $enc -x ".$config{bowtie_path}." -1 ".$files[0]." -2 ".$files[1]." | samtools view -bS - > $output_fn";
-			warn "\n###CFCMD $command\n\n";
+			$command .= "bowtie2 -p $cores -t $enc -x ".$config{bowtie_path}." -1 ".$files[0]." -2 ".$files[1]." | samtools view -bS - > $output_fn";
+			warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 			
 			if(!system ($command)){
 				# Bowtie worked - print out resulting filenames

--- a/modules/cf_run_finished.cfmod
+++ b/modules/cf_run_finished.cfmod
@@ -135,9 +135,10 @@ foreach my $key (sort { $modkeys{$a} <=> $modkeys{$b} or $a cmp $b } keys %modke
 	$outfile .= $modules{$key}."\n\n\n";
 }
 # count non-whitespace characters only
-if((()= $unrecognised =~ m/\S/g) > 0){
-	$outfile .= ("-"x80)."\nUnrecognised output:\n".("-"x80)."\n".$unrecognised;
+if($unrecognised =~ m/\S/g){
+	$outfile .= ("-"x80)."\nUnrecognised output: (indicated with \"->foo<-\")\n".("-"x80)."\n->".join("<-\n->", split "\n", $unrecognised)."<-\n\n";
 }
+$outfile .= ("="x80)."\n\n\n";
 
 # Write out the cleaned runfile without any crap
 open (OUT,'>',$outfn) or die "Can't write to $outfn: $!";

--- a/modules/example_module
+++ b/modules/example_module
@@ -172,7 +172,15 @@ my ($se_files, $pe_files) = CF::Helpers::is_paired_end(\%config, @$files);
 # Go through each SINGLE END file and run our command
 #
 if($se_files && scalar(@$se_files) > 0){
+	my $first = 1;
 	foreach my $file (@$se_files){
+		my $command = "";
+		if ($first and grep(/^report_v$/, @$parameters) > 0){
+			# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+			$command .= "MY_COMMAND --version\n"; # assuming your program accepts --version as an argument
+			$command .= "echo ---------- MY COMMAND output follows ---------- \n";
+			$first = 0;
+		}
 		
 		# Figure out the encoding if we don't already know
 		if(!$encoding){
@@ -188,9 +196,9 @@ if($se_files && scalar(@$se_files) > 0){
 		my $output_fn = $file."_processed.output";
 		
 		# Write our command!
-		my $command = "my_command $enc $param1 $param2 -c $cores -m $mem -g ".$config{genome_path}." -i $file -o $output_fn";
+		$command .= "my_command $enc $param1 $param2 -c $cores -m $mem -g ".$config{genome_path}." -i $file -o $output_fn";
 		# Write the command to the log file
-		warn "\n###CFCMD $command\n\n";
+		warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 		
 		# Try to run the command - returns 0 on success (which evaluated to false)
 		if(!system ($command)){
@@ -223,11 +231,19 @@ if($se_files && scalar(@$se_files) > 0){
 # Go through each pair of PAIRED END files and run our command
 #
 if($pe_files && scalar(@$pe_files) > 0){
+	my $first = 1;
 	foreach my $files_ref (@$pe_files){
 		my @files = @$files_ref;
 		
 		# Check that we do actually have two files here
 		if(scalar(@files) == 2){
+			my $command = "";
+			if ($first and grep(/^report_v$/, @$parameters) > 0){
+				# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+				$command .= "MY_COMMAND --version\n";  # assuming your program accepts --version as an argument
+				$command .= "echo ---------- MY COMMAND output follows ---------- \n";
+				$first = 0;
+			}
 			
 			# Figure out the encoding if we don't already know
 			if(!$encoding){
@@ -243,9 +259,9 @@ if($pe_files && scalar(@$pe_files) > 0){
 			my $output_fn = $files[0]."_".$files[1]."_processed.output";
 			
 			# Write our command!
-			my $command = "my_command $enc $param1 $param2 -c $cores -m $mem -g ".$config{genome_path}." -1 ".$files[0]." -2 ".$files[1]." -o $output_fn";
+			$command .= "my_command $enc $param1 $param2 -c $cores -m $mem -g ".$config{genome_path}." -1 ".$files[0]." -2 ".$files[1]." -o $output_fn";
 			# Write the command to the log file
-			warn "\n###CFCMD $command\n\n";
+			warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 			
 			# Try to run the command - returns 0 on success (which evaluated to false)
 			if(!system ($command)){

--- a/modules/htseq_counts.cfmod
+++ b/modules/htseq_counts.cfmod
@@ -89,11 +89,19 @@ foreach my $parameter (@$parameters){
 
 
 # Go through each supplied file and run FastQC.
+my $first = 1;
 foreach my $file (@$files){
+	my $command = "";
+	if ($first and grep(/^report_v$/, @$parameters) > 0){
+		# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+		$command .= "htseq-count --help\n";
+		$command .= "echo ---------- htseq-count output follows ---------- \n";
+		$first = 0;
+	}
 	my $annotated_file = $file."_annotated.sam";
 	my $counts_file = $file."_counts.txt";
-	my $command = "samtools view -h $file | htseq-count -o $annotated_file -t exon $stranded -q -i 'ID' - ".$config{gtf_path}." | sort -n -k 2 -r > $counts_file";
-	warn "\n###CFCMD $command\n\n";
+	$command .= "samtools view -h $file | htseq-count -o $annotated_file -t exon $stranded -q -i 'ID' - ".$config{gtf_path}." | sort -n -k 2 -r > $counts_file";
+	warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 	
 	if(!system ($command)){
 		print RUN "$job_id\t$annotated_file\n";

--- a/modules/samtools_sort.cfmod
+++ b/modules/samtools_sort.cfmod
@@ -86,11 +86,17 @@ open (RUN,'>>',$runfile) or die "Can't write to $runfile: $!";
 
 # we want e.g. samtools view -bS ./test2_trimmedAligned.out.sam | samtools sort - outfile
 
+my $first = 1;
 foreach my $file (@$files){
 		
 	# Figure out the file type
 	my $command = "";
-	$command .= "samtools\n echo ----- samtools output follows ----- \n" if ($$files[0] == $file); # print version number etc on first iteration
+	if ($first and grep(/^report_v$/, @$parameters) > 0){
+		# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+		$command .= "samtools\n";
+		$command .= "echo ---------- samtools output follows ---------- \n";
+		$first = 0;
+	}
 	my $prefix = $file;
 	my $filetype = "";
 	if ($prefix =~ s/\.([sb]am$)//){
@@ -114,7 +120,7 @@ foreach my $file (@$files){
 	
 	$command .= " samtools sort -m $mem_per_thread $namesort $sortfile  $output_fn";
 	
-	warn "\n###CFCMD $command\n\n";
+	warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 	
 	$output_fn .= '.bam';  # with samtools < v1.0 only prefix is specified, have to add .bam after calling command
 	

--- a/modules/star.cfmod
+++ b/modules/star.cfmod
@@ -113,7 +113,16 @@ my $encoding = 0;
 
 # Go through each single end file and run STAR
 if($se_files && scalar(@$se_files) > 0){
+	my $first = 1;
 	foreach my $file (@$se_files){
+		my $command = "";
+		if ($first and grep(/^report_v$/, @$parameters) > 0){
+			# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+			$command .= "STAR --version\n";
+			$command .= "echo \n"; # STAR doesn't add its own newline to version output
+			$command .= "echo ---------- STAR output follows ---------- \n";
+			$first = 0;
+		}
 		
 		# Figure out the encoding if we don't already know
 		if(!$encoding){
@@ -132,13 +141,13 @@ if($se_files && scalar(@$se_files) > 0){
 	
 		my $output_fn = $prefix."Aligned.out.sam";
 		
-		my $command = "STAR --runThreadN $cores $enc --outSAMattributes All --genomeLoad $genomeLoad";  
+		$command .= "STAR --runThreadN $cores $enc --outSAMattributes All --genomeLoad $genomeLoad";  
 		if ($file =~ /\.gz$/) {
 			$command .= " --readFilesCommand zcat";	#code
 		}
 		
 		$command .= " --genomeDir ".$config{star_path}." --readFilesIn $file --outFileNamePrefix $prefix";
-		warn "\n###CFCMD $command\n\n";
+		warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 		
 		if(!system ($command)){
 			# STAR worked - print out resulting filenames
@@ -157,9 +166,18 @@ if($se_files && scalar(@$se_files) > 0){
 
 # Go through the paired end files and run STAR
 if($pe_files && scalar(@$pe_files) > 0){
+	my $first = 1;
 	foreach my $files_ref (@$pe_files){
 		my @files = @$files_ref;
 		if(scalar(@files) == 2){
+			my $command = "";
+			if ($first and grep(/^report_v$/, @$parameters) > 0){
+				# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+				$command .= "STAR --version\n";
+				$command .= "echo \n"; # STAR doesn't add its own newline to version output
+				$command .= "echo ---------- STAR output follows ---------- \n";
+				$first = 0;
+			}
 				
 			# Figure out the encoding if we don't already know
 			if(!$encoding){
@@ -179,13 +197,13 @@ if($pe_files && scalar(@$pe_files) > 0){
 		
 			my $output_fn = $prefix."Aligned.out.sam";
 			
-			my $command = "STAR --runThreadN $cores $enc --outSAMattributes All --genomeLoad $genomeLoad";
+			$command .= "STAR --runThreadN $cores $enc --outSAMattributes All --genomeLoad $genomeLoad";
 			if ($files[0] =~ /\.gz$/) {
 				$command .= " --readFilesCommand zcat";	#code
 			}
 			
 			$command .= " --genomeDir ".$config{star_path}." --readFilesIn $files[0] $files[1] --outFileNamePrefix $prefix";
-			warn "\n###CFCMD $command\n\n";
+			warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 			
 			if(!system ($command)){
 				# STAR worked - print out resulting filenames

--- a/modules/tophat.cfmod
+++ b/modules/tophat.cfmod
@@ -109,7 +109,15 @@ my $encoding = 0;
 # Go through each single end files and run Tophat
 my $output_dir;
 if($se_files && scalar(@$se_files) > 0){
+	my $first = 1;
 	foreach my $file (@$se_files){
+		my $command = "";
+		if ($first and grep(/^report_v$/, @$parameters) > 0){
+			# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+			$command .= "tophat --version\n";
+			$command .= "echo ---------- Tophat output follows ---------- \n";
+			$first = 0;
+		}
 		
 		# Figure out the encoding if we don't already know
 		if(!$encoding){
@@ -137,8 +145,8 @@ if($se_files && scalar(@$se_files) > 0){
 		my $output_fn = $output_dir."/accepted_hits.bam";
 		
 		# Changing the command to -g 2 so that we can get proper MAPQ values
-		my $command = "tophat -p $cores -g 2 $enc $gtf -o $output_dir ".$config{bowtie_path}." $file";
-		warn "\n###CFCMD $command\n\n";
+		$command .= "tophat -p $cores -g 2 $enc $gtf -o $output_dir ".$config{bowtie_path}." $file";
+		warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 		
 		if(!system ($command)){
 			# Tophat worked - print out resulting filenames
@@ -159,9 +167,17 @@ if($se_files && scalar(@$se_files) > 0){
 
 # Go through the paired end files and run Tophat
 if($pe_files && scalar(@$pe_files) > 0){
+	my $first = 1;
 	foreach my $files_ref (@$pe_files){
 		my @files = @$files_ref;
 		if(scalar(@files) == 2){
+			my $command = "";
+			if ($first and grep(/^report_v$/, @$parameters) > 0){
+				# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+				$command .= "tophat --version\n";
+				$command .= "echo ---------- Tophat output follows ---------- \n";
+				$first = 0;
+			}
 			
 			# Figure out the encoding if we don't already know
 			if(!$encoding){
@@ -189,8 +205,8 @@ if($pe_files && scalar(@$pe_files) > 0){
 			my $output_fn = $output_dir."/accepted_hits.bam";
 			
             # Changing the command to -g 2 so that we can get proper MAPQ values
-			my $command = "tophat -p $cores -g 2 $enc $gtf -o $output_dir ".$config{bowtie_path}." ".$files[0]." ".$files[1];
-			warn "\n###CFCMD $command\n\n";
+			$command .= "tophat -p $cores -g 2 $enc $gtf -o $output_dir ".$config{bowtie_path}." ".$files[0]." ".$files[1];
+			warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 			
 			if(!system ($command)){
 				# Tophat worked - print out resulting filenames

--- a/modules/trim_galore.cfmod
+++ b/modules/trim_galore.cfmod
@@ -134,7 +134,18 @@ my $encoding = 0;
 
 # Go through each single end files and run trim galore
 if($se_files && scalar(@$se_files) > 0){
+	my $first = 1;
 	foreach my $file (@$se_files){
+		my $command = "";
+		if ($first and grep(/^report_v$/, @$parameters) > 0){
+			# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+			$command .= "echo cutadapt version:\n";
+			$command .= "cutadapt --version \n";
+			$command .= "echo trim_galore version:\n";
+			$command .= "trim_galore --version\n";
+			$command .= "echo ---------- trim_galore output follows ---------- \n";
+			$first = 0;
+		}
 		
 		# Figure out the encoding if we don't already know
 		if(!$encoding){
@@ -151,9 +162,9 @@ if($se_files && scalar(@$se_files) > 0){
 			$fqc = " --fastqc_args \"-q\" ";
 		}
 		
-		my $command = "trim_galore --gzip $enc $stringency $RRBS $adapter $q_cutoff $clip_r1 $fqc $file";
+		$command .= "trim_galore --gzip $enc $stringency $RRBS $adapter $q_cutoff $clip_r1 $fqc $file";
 
-		warn "\n###CFCMD $command\n\n";
+		warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 		
 		if(!system ($command)){
 			# Trim Galore worked - print out resulting filenames
@@ -172,9 +183,18 @@ if($se_files && scalar(@$se_files) > 0){
 
 # Go through the paired end files and run trim galore
 if($pe_files && scalar(@$pe_files) > 0){
+	my $first = 1;
 	foreach my $files_ref (@$pe_files){
 		my @files = @$files_ref;
 		if(scalar(@files) == 2){
+			my $command = "";
+			if ($first and grep(/^report_v$/, @$parameters) > 0){
+				# print version number etc if 1) first iteration and 2) if parameters contains "report_v"
+				$command .= "echo cutadapt version:\n cutadapt --version \n";
+				$command .= "echo trim_galore version: \n trim_galore --version \n";
+				$command .= "echo ---------- trim_galore output follows ---------- \n";
+				$first = 0;
+			}	
 			
 			# Figure out the encoding if we don't already know
 			if(!$encoding){
@@ -196,9 +216,9 @@ if($pe_files && scalar(@$pe_files) > 0){
 				$fqc = " --fastqc ";
 			}
 			
-			my $command = "trim_galore --paired --trim1 --gzip $enc $stringency $RRBS $adapter $q_cutoff $clip_r1 $clip_r2 $fqc $files[0] $files[1]";
+			$command .= "trim_galore --paired --trim1 --gzip $enc $stringency $RRBS $adapter $q_cutoff $clip_r1 $clip_r2 $fqc $files[0] $files[1]";
 			
-			warn "\n###CFCMD $command\n\n";
+			warn "\n###CFCMD ".join("\n###CFCMD ", split /\n/, $command)."\n\n";
 			
 			if(!system ($command)){
 				# Trim Galore worked - print out resulting filenames


### PR DESCRIPTION
Hi, Phil, I wanted to include the version numbers of the programs called by clusterflow in the run report file for `--verbose` mode, so I edited the cfmod files for samtools, bowtie etc. to output this to the clusterflow report file if `report_v` is in the params (`--verbose` now adds `report_v` to the params fed to all modules). For some programs it's impossible to get version info without also getting the help page, I could have pared this down (e.g. `htseq-count | tail -n 3`) but I chose not to because we can't predict the format of future versions of their help pages.

Anyway I also noticed that the report file for some reason doesn't recognise some of its own output, from the email scheduling cfmod it looks like. It's not a serious issue. I tagged unrecognised output with arrows in the report file to highlight it too.