### PR TITLE
Updates for deeptools and phantompeaktools modules

### DIFF
--- a/modules/deeptools_bamCoverage.cfmod.pl
+++ b/modules/deeptools_bamCoverage.cfmod.pl
@@ -104,7 +104,7 @@ foreach my $file (@{$cf{'prev_job_files'}}){
 
     # Run bamCoverage, to get bigWig file
     # my $cmd = "bamCoverage -f $fragmentLength -p $cf{cores} -b $file -o $output_fn";
-    my $cmd = "bamCoverage --normalizeUsingRPKM= --extendReads $fragmentLength -p $cf{cores} -b $file -o $output_fn";  
+    my $cmd = "bamCoverage --normalizeUsingRPKM --extendReads $fragmentLength -p $cf{cores} -b $file -o $output_fn";  
     warn "\n###CFCMD $cmd\n\n";
 
     # Try to run the command - returns 0 on success (which evaluated to false)

--- a/modules/deeptools_bamCoverage.cfmod.pl
+++ b/modules/deeptools_bamCoverage.cfmod.pl
@@ -43,13 +43,12 @@ my %requirements = (
 
 # The help text
 my $helptext = "".("-"x15)."\n DeepTools bamCoverage\n".("-"x15)."\n
-Takes two input files: a bam file and a _crosscorrelation.txt file,
+Takes two input files: a bam file and an (optional) _crosscorrelation.txt file,
 as created by phantompeaktools. Creates a bigWig coverage file,
 using deepTools/bamCoverage. Outputs are are bw files named basename.bw.
 The fragment length is set using 1) the input parameter fragmentLength
 2) the file _crosscorrelation.txt and 3) default fragment length of 200
-(if no input parameter is set and the file _crosscorrelation.txt doesn't exist).
-Currently this module expects a locally installed bamCoverage script.\n\n";
+(if no input parameter is set and the file _crosscorrelation.txt doesn't exist).\n\n";
 
 # Start your engines...
 my %cf = CF::Helpers::module_start(\%requirements, $helptext);
@@ -104,14 +103,15 @@ foreach my $file (@{$cf{'prev_job_files'}}){
     my $output_fn = $file."_coverage.bw";
 
     # Run bamCoverage, to get bigWig file
-    my $cmd = "bamCoverage -f $fragmentLength -p $cf{cores} -b $file -o $output_fn";
+    # my $cmd = "bamCoverage -f $fragmentLength -p $cf{cores} -b $file -o $output_fn";
+    my $cmd = "bamCoverage --normalizeUsingRPKM= --extendReads $fragmentLength -p $cf{cores} -b $file -o $output_fn";  
     warn "\n###CFCMD $cmd\n\n";
 
     # Try to run the command - returns 0 on success (which evaluated to false)
     if(!system ($cmd)){
 	# Command worked!
 	# Work out how long the processing took
-	my $duration =  CF::Helpers::parse_seconds(time - $timestart);
+	my $duration = CF::Helpers::parse_seconds(time - $timestart);
 
 	# Print a success message to the log file which will be e-mailed out
 	warn "###CF bamCoverage successfully exited, took $duration..\n";

--- a/modules/deeptools_bamFingerprint.cfmod.pl
+++ b/modules/deeptools_bamFingerprint.cfmod.pl
@@ -44,14 +44,13 @@ my %requirements = (
 
 # The help text
 my $helptext = "".("-"x15)."\n DeepTools bamFingerprint\n".("-"x15)."\n
-Takes two input files: a bam file and a _crosscorrelation.txt file,
+Takes two input files: a bam file and an (optional) _crosscorrelation.txt file,
 as created by phantompeaktools. Creates a \"fingerprint\" plot of
-the read coverage, using deepTools/bamFingerprint. Outputs are are
+the read coverage, using deepTools/plotFingerprint. Outputs are are
 plot files named basename_fingerprint.png. The fragment length is set
 using 1) the input parameter fragmentLength 2) the file _crosscorrelation.txt
 and 3) default fragment length of 200 (if no input parameter is set
-and the file _crosscorrelation.txt doesn't exist). Currently expects
-a locally installed bamFingerprint.\n\n";
+and the file _crosscorrelation.txt doesn't exist). \n\n";
 
 
 # Start your engines...
@@ -62,7 +61,7 @@ my $defaultFragLen = 200; # If fragment length not defined, use this value.
 
 # Print version information about the program to be executed.
 warn "---------- bamFingerprint  version information ----------\n";
-warn `bamFingerprint --version`;
+warn `plotFingerprint --version`;
 warn "\n------- End of bamFingerprint version information ------\n";
 
 # Open up our run file in append mode
@@ -109,7 +108,7 @@ foreach my $file (@{$cf{'prev_job_files'}}){
 
     # Run bamFingerprint, to get bigWig file
 
-    my $cmd = "bamFingerprint -b $file -p $cf{cores} --fragmentLength $fragmentLength -plot $output_fn";
+    my $cmd = "plotFingerprint -b $file --numberOfProcessors $cf{cores} --extendReads $fragmentLength -plot $output_fn";
     warn "\n###CFCMD $cmd\n\n";
 
 

--- a/modules/phantompeaktools_runSpp.cfmod.pl
+++ b/modules/phantompeaktools_runSpp.cfmod.pl
@@ -28,7 +28,7 @@ use CF::Helpers;
 
 my %requirements = (
 	'cores' 	=> '1',
-	'memory' 	=> '2G',
+	'memory' 	=> '8G',
 	'modules' 	=> ['phantompeakqualtools', 'samtools'],
 	'time' 		=> sub {
 
@@ -36,8 +36,8 @@ my %requirements = (
 		my $num_files = $cf->{'num_starting_merged_aligned_files'};
 		# Default to 1 if none were parsed for whatever reason
 		$num_files = ($num_files > 0) ? $num_files : 1;
-		# Picard usually takes around 30 minutes per BAM file?
-		return CF::Helpers::minutes_to_timestamp ($num_files * 1 * 60);
+		# Usually takes around 90 minutes per BAM file?
+		return CF::Helpers::minutes_to_timestamp ($num_files * 1 * 240);
 	}
 );
 


### PR DESCRIPTION
Fixed the deeptools modules, so they work with DeepTools 2.0. Also made some small fixes:
- deepTools now computes RPKM coverage instead of raw read count coverage
- time limits for deeptools_bamCoverage, deeptools_bamFingerprint, and phantompeaktools_runSpp have been increased.
(- comments have beed updated)