### PR TITLE
ChIP-seq pipeline: removing reads in blacklist regions

### DIFF
--- a/modules/bedtools_intersectNeg.cfmod.pl
+++ b/modules/bedtools_intersectNeg.cfmod.pl
@@ -1,0 +1,118 @@
+#!/usr/bin/env perl
+use warnings;
+use strict;
+use Getopt::Long;
+use FindBin qw($Bin);
+use lib "$FindBin::Bin/../source";
+use CF::Constants;
+use CF::Helpers;
+
+##########################################################################
+# Copyright 2014, Philip Ewels (phil.ewels@babraham.ac.uk)               #
+#                                                                        #
+# This file is part of Cluster Flow.                                     #
+#                                                                        #
+# Cluster Flow is free software: you can redistribute it and/or modify   #
+# it under the terms of the GNU General Public License as published by   #
+# the Free Software Foundation, either version 3 of the License, or      #
+# (at your option) any later version.                                    #
+#                                                                        #
+# Cluster Flow is distributed in the hope that it will be useful,        #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of         #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          #
+# GNU General Public License for more details.                           #
+#                                                                        #
+# You should have received a copy of the GNU General Public License      #
+# along with Cluster Flow.  If not, see <http://www.gnu.org/licenses/>.  #
+##########################################################################
+
+my %requirements = (
+	'cores' 	=> ['2', '4'],
+	'memory' 	=> ['8G', '16G'],
+	'modules' 	=> 'BEDTools',
+	'time' 		=> sub {
+
+		my $cf = $_[0];
+		my $num_files = $cf->{'num_starting_merged_aligned_files'};
+		# Default to 1 if none were parsed for whatever reason
+		$num_files = ($num_files > 0) ? $num_files : 1;
+		# To be safe, we set the time limit to 1 hour per bam file.
+		return CF::Helpers::minutes_to_timestamp ($num_files * 1 * 60);
+	}
+);
+
+# The help text
+my $helptext = "".("-"x15)."\n Bedtools intersectNeg\n".("-"x15)."\n
+Takes a bam file and a bed file with regions, given by the flag blacklistFile. 
+Filters the bam file, so the only reads not present in the blacklist regions 
+are included in the output. Usees bedtools intesect for this.\n\n";
+
+# Start your engines...
+my %cf = CF::Helpers::module_start(\%requirements, $helptext);
+
+# Print version information about the program to be executed.
+warn "---------- Bedtools version information ----------\n";
+warn `bedtools --version`;
+warn "\n------- End of bedtools version information ------\n";
+
+# Open up our run file in append mode
+open (RUN,'>>',$cf{'run_fn'}) or die "###CF Error: Can't write to $cf{run_fn}: $!";
+
+# Go through each file and run our command
+foreach my $file (@{$cf{'prev_job_files'}}){
+  # Start the clock...
+  my $timestart = time;
+
+  # Check that input is bam file
+  if($file !~ /\.bam$/i){
+      warn "\n###CF Error! bedtools_intersectNeg failed: bam file expected, got $file\n\n";
+      next;
+  }
+
+  # Generate a nice output file name
+  (my $output_fn = $file) =~ s/\.bam//i;
+  $output_fn .= "_noblacklist.bam";
+
+
+  # Check if a file with blacklist regions was provided.
+  my $blacklistFile;
+  if(defined($cf{'params'}{'blacklistFile'})){
+      $blacklistFile = $cf{'params'}{'blacklistFile'};
+      warn "###CF bedtools intersectNeg: Using blacklist file $blacklistFile.\n";
+  } else {
+      warn "###CF bedtools intersectNeg: No blacklist file given. Skipping this step.\n";
+      print RUN "$cf{job_id}\t$file\n";
+      next;
+  }
+
+
+  ## Run bedtools intersect to remove reads from blacklist regions
+  my $cmd = "bedtools intersect -abam $file -b $blacklistFile -v > $output_fn";
+  warn "\n###CFCMD $cmd\n\n";
+
+  # Try to run the command - returns 0 on success (which evaluated to false)
+  if(!system ($cmd)){
+    # Command worked!
+    # Work out how long the processing took
+    my $duration =  CF::Helpers::parse_seconds(time - $timestart);
+
+    # Print a success message to the log file which will be e-mailed out
+    warn "###CFBedtools intersectNeg successfully exited, took $duration..\n";
+
+    # Check we can find our output filename!
+    if(-e $output_fn){
+      # Print the current job ID and the output filename to the run file
+      # This is so that subsequent modules can use this output
+      print RUN "$cf{job_id}\t$output_fn\n";
+    } else {
+      # Oops - can't find the output file! Err...
+      warn "\nBedtools intersectNeg output file $output_fn not found..\n";
+    }
+  } else {
+    # Command returned a non-zero result, probably went wrong...
+    warn "\n###CF Error! Bedtools intersectNeg failed for '$file': $? $!\n\n";
+  }
+}
+
+# Close the run file
+close (RUN);

--- a/modules/cf_merge_files.cfmod.pl
+++ b/modules/cf_merge_files.cfmod.pl
@@ -30,7 +30,7 @@ use POSIX;
 # Module requirements
 my %requirements = (
 	'cores' 	=> '1',
-	'memory' 	=> '3G',
+	'memory' 	=> '8G',
 	'modules' 	=> 'samtools',
 	'time' 		=> sub {
 		my $cf = $_[0];

--- a/pipelines/chipseq_qc.config
+++ b/pipelines/chipseq_qc.config
@@ -16,4 +16,7 @@ fingerprint plot. Also runs fastQC on the fastq files.
 				#phantompeaktools_runSpp
 					#deeptools_bamCoverage
 					#deeptools_bamFingerprint
+				#bedtools_intersectNeg
+					#samtools_sort_index
+
 


### PR DESCRIPTION
Added a module to remove read in blacklist regions (e.g. from ENCODE), which uses bedtools intersect.
(Also raised the memory for cf_merge)