### PR TITLE
Changed hisat output filename generation to be cleaner and include ge…

### DIFF
--- a/modules/bismark_align.cfmod.pl
+++ b/modules/bismark_align.cfmod.pl
@@ -118,6 +118,7 @@ if($se_files && scalar(@$se_files) > 0){
 		
 		my $output_fn = $file;
 		$output_fn =~ s/(\.fastq\.gz|\.fq\.gz|\.fastq|\.fq)$//; # attempting to remove fastq.gz etc to make filename a little shorter 05 02 2016. Felix
+		$output_fn .= "_".$cf{config}{genome};
 		if($bowtie == '--bowtie2'){
 		    $output_fn .= "_bismark_bt2.bam";
 		} else {
@@ -162,6 +163,8 @@ if($pe_files && scalar(@$pe_files) > 0){
 			
 			my $output_fn = $files[0];
 			$output_fn =~ s/(\.fastq\.gz|\.fq\.gz|\.fastq|\.fq)$//; # attempting to remove fastq.gz etc to make filename a little shorter 05 02 2016. Felix
+			$output_fn .= "_".$cf{config}{genome};
+
 			if($bowtie == '--bowtie2'){
 			    $output_fn .= "_bismark_bt2_pe.bam";
 			} else {

--- a/modules/bowtie1.cfmod.pl
+++ b/modules/bowtie1.cfmod.pl
@@ -92,7 +92,11 @@ if($se_files && scalar(@$se_files) > 0){
 			$enc = '--'.$encoding.'-quals';
 		}
 
-		my $output_fn = $file."_bowtie.bam";
+		my $output_fn = $file;
+		$output_fn =~ s/\.gz$//i;
+		$output_fn =~ s/\.(fq|fastq)$//i;
+		$output_fn .= "_".$cf{config}{genome};
+		$output_fn .= "_bowtie.bam";
 
 		my $gzip = "";
 		if($file =~ /\.gz$/){
@@ -147,7 +151,11 @@ if($pe_files && scalar(@$pe_files) > 0){
 				$files[1] =~ s/.gz$//;
 			}
 
-			my $output_fn = $files[0]."_bowtie.bam";
+			my $output_fn = $files[0];
+			$output_fn =~ s/\.gz$//i;
+			$output_fn =~ s/\.(fq|fastq)$//i;
+			$output_fn .= "_".$cf{config}{genome};
+			$output_fn .= "_bowtie.bam";
 
 			my $command = "bowtie -p $cf{cores} -t -m 1 $enc --strata --best --maxins 700 -S --chunkmbs 512 $cf{refs}{bowtie} -1 ".$files[0]." -2 ".$files[1]." | samtools view -bSh 2>/dev/null - > $output_fn";
 

--- a/modules/bowtie2.cfmod.pl
+++ b/modules/bowtie2.cfmod.pl
@@ -91,7 +91,11 @@ if($se_files && scalar(@$se_files) > 0){
 			$enc = '--'.$encoding.'-quals';
 		}
 
-		my $output_fn = $file."_bowtie2.bam";
+		my $output_fn = $file;
+		$output_fn =~ s/\.gz$//i;
+		$output_fn =~ s/\.(fq|fastq)$//i;
+		$output_fn .= "_".$cf{config}{genome};
+		$output_fn .= "_bowtie2.bam";
 
 		my $command = "bowtie2 -p $cf{cores} -t $enc -x $cf{refs}{bowtie2} -U $file | samtools view -bS - > $output_fn";
 		warn "\n###CFCMD $command\n\n";
@@ -127,7 +131,11 @@ if($pe_files && scalar(@$pe_files) > 0){
 				$enc = '--'.$encoding.'-quals';
 			}
 
-			my $output_fn = $files[0]."_bowtie2.bam";
+			my $output_fn = $files[0];
+			$output_fn =~ s/\.gz$//i;
+			$output_fn =~ s/\.(fq|fastq)$//i;
+			$output_fn .= "_".$cf{config}{genome};
+			$output_fn .= "_bowtie2.bam";
 
 			my $command = "bowtie2 -p $cf{cores} -t $enc -x $cf{refs}{bowtie2} -1 ".$files[0]." -2 ".$files[1]." | samtools view -bS - > $output_fn";
 			warn "\n###CFCMD $command\n\n";

--- a/modules/bwa.cfmod.pl
+++ b/modules/bwa.cfmod.pl
@@ -76,7 +76,11 @@ if($se_files && scalar(@$se_files) > 0){
 	foreach my $file (@$se_files){
 		my $timestart = time;
 
-        my $output_fn = $file."_bwa.bam";
+		my $output_fn = $file;
+		$output_fn =~ s/\.gz$//i;
+		$output_fn =~ s/\.(fq|fastq)$//i;
+		$output_fn .= "_".$cf{config}{genome};
+		$output_fn .= "_bwa.bam";
 
 		my $command = "bwa mem -t $cf{cores} $cf{refs}{bwa} $file | samtools view -bS - > $output_fn";
 		warn "\n###CFCMD $command\n\n";
@@ -103,7 +107,11 @@ if($pe_files && scalar(@$pe_files) > 0){
 		if(scalar(@files) == 2){
 			my $timestart = time;
 
-            my $output_fn = $files[0]."_bwa.bam";
+			my $output_fn = $files[0];
+			$output_fn =~ s/\.gz$//i;
+			$output_fn =~ s/\.(fq|fastq)$//i;
+			$output_fn .= "_".$cf{config}{genome};
+			$output_fn .= "_bwa.bam";
 
     		my $command = "bwa mem -t $cf{cores} $cf{refs}{bwa} $files[0] $files[1] | samtools view -bS - > $output_fn";
     		warn "\n###CFCMD $command\n\n";

--- a/modules/hicup.cfmod.pl
+++ b/modules/hicup.cfmod.pl
@@ -225,7 +225,8 @@ if($pe_files && scalar(@$pe_files) > 0){
 
                 unless ( defined $pairedFilename ) {
                     $pairedFilename = "$file1.$file2";
-                }		
+                }
+				$pairedFilename .= "_".$cf{config}{genome};				
 				$pairedFilename .= '.hicup.bam';
 				$output_fn = $pairedFilename;
             }

--- a/modules/hisat2.cfmod.pl
+++ b/modules/hisat2.cfmod.pl
@@ -75,9 +75,9 @@ if(defined($cf{'refs'}{'hisat2_splices'}) && -e $cf{'refs'}{'hisat2_splices'}){
 open (RUN,'>>',$cf{'run_fn'}) or die "###CF Error: Can't write to $cf{run_fn}: $!";
 
 # Print version information about the module.
-warn "---------- Tophat version information ----------\n";
+warn "---------- Hisat2 version information ----------\n";
 warn `hisat2 --version`;
-warn "\n------- End of Tophat version information ------\n";
+warn "\n------- End of Hisat2 version information ------\n";
 
 # Separate file names into single end and paired end
 my ($se_files, $pe_files) = CF::Helpers::is_paired_end(\%cf, @{$cf{'prev_job_files'}});
@@ -99,7 +99,11 @@ if($se_files && scalar(@$se_files) > 0){
 			$enc = '--'.$encoding.'-quals';
 		}
 		
-		my $output_fn = $file."_hisat2.bam";
+    my $output_fn = $file;
+		$output_fn =~ s/\.gz$//i;
+		$output_fn =~ s/\.(fq|fastq)$//i;
+		$output_fn .= "_".$cf{config}{genome};
+		$output_fn .= "_hisat2.bam";
 		
 		# we are currently using a very high penalty score for soft-clipping (--sp 1000,1000) because Hisat2 seems to soft-clip even when it should run in --end-to-end mode
 		# we are also filtering out unmapped reads (-F 4)
@@ -140,7 +144,11 @@ if($pe_files && scalar(@$pe_files) > 0){
 				$enc = '--'.$encoding.'-quals';
 			}
 			
-			my $output_fn = $files[0]."_hisat2.bam";
+			my $output_fn = $files[0];
+			$output_fn =~ s/\.gz$//i;
+			$output_fn =~ s/\.(fq|fastq)$//i;
+			$output_fn .= "_".$cf{config}{genome};
+			$output_fn .= "_hisat2.bam";
 			
 			#  we are currently using a very high penalty score for soft-clipping (--sp 1000,1000) because Hisat2 seems to soft-clip even when it shoudl run in --end-to-end mode
 			# we are also filtering out unmapped reads (-F 4), or reads where the mate was unmapped (-F 8)

--- a/modules/kallisto.cfmod.pl
+++ b/modules/kallisto.cfmod.pl
@@ -93,10 +93,14 @@ if($se_files && scalar(@$se_files) > 0){
 			$enc = '--'.$encoding.'-quals';
 		}
 
-                my $output_dir = $file."_kallisto_output";
-		my $output_fn  = $file."_kallisto.bam";
+		my $output_dir = $file."_kallisto_output";
+		my $output_fn = $file;
+		$output_fn =~ s/\.gz$//i;
+		$output_fn =~ s/\.(fq|fastq)$//i;
+		$output_fn .= "_".$cf{config}{genome};
+		$output_fn .= "_kallisto.bam";
                 
-                my $command = "kallisto quant -t $cf{cores} --pseudobam --single -i $cf{refs}{kallisto} -o $output_dir -b 100 $file | samtools view -Sb - > $output_fn";
+		my $command = "kallisto quant -t $cf{cores} --pseudobam --single -i $cf{refs}{kallisto} -o $output_dir -b 100 $file | samtools view -Sb - > $output_fn";
 		warn "\n###CFCMD $command\n\n";
 
 		if(!system ($command)){
@@ -130,10 +134,14 @@ if($pe_files && scalar(@$pe_files) > 0){
 				$enc = '--'.$encoding.'-quals';
 			}
 
-                        my $output_dir = $files[0]."_kallisto_output";
-                        my $output_fn  = $files[0]."_kallisto.bam";
+			my $output_dir = $files[0]."_kallisto_output";
+			my $output_fn = $files[0];
+			$output_fn =~ s/\.gz$//i;
+			$output_fn =~ s/\.(fq|fastq)$//i;
+			$output_fn .= "_".$cf{config}{genome};
+			$output_fn .= "_kallisto.bam";
 
-                        my $command = "kallisto quant -t $cf{cores} --pseudobam -i $cf{refs}{kallisto} -o $output_dir -b 100 $files[0] $files[1] | samtools view -Sb - > $output_fn";
+			my $command = "kallisto quant -t $cf{cores} --pseudobam -i $cf{refs}{kallisto} -o $output_dir -b 100 $files[0] $files[1] | samtools view -Sb - > $output_fn";
 			warn "\n###CFCMD $command\n\n";
 
 			if(!system ($command)){

--- a/modules/star.cfmod.pl
+++ b/modules/star.cfmod.pl
@@ -118,7 +118,8 @@ foreach my $file (@$se_files){
 	$prefix =~ s/\_R1_001$//;
 	$prefix =~ s/\_R1$//i;
 	$prefix =~ s/\_val_1$//;
-	my $output_fn = $prefix."_star_aligned.bam";
+	$prefix .= "_".$cf{config}{genome};
+	my $output_fn = $prefix."_star.bam";
 
 	my $command = "STAR --runThreadN $cf{cores} $enc --outSAMattributes $sam_attributes --genomeLoad $genomeLoad $zcat --genomeDir $cf{refs}{star} --readFilesIn $file --outFileNamePrefix $prefix --outStd SAM | samtools view -bS - > $output_fn";
 	warn "\n###CFCMD $command\n\n";
@@ -161,7 +162,8 @@ foreach my $files_ref (@$pe_files){
 		$prefix =~ s/\_R1_001$//;
 		$prefix =~ s/\_R1$//i;
 		$prefix =~ s/\_val_1$//;
-		my $output_fn = $prefix."_star_aligned.bam";
+		$prefix .= "_".$cf{config}{genome};
+		my $output_fn = $prefix."_star.bam";
 
 		# Do we need to zcat this?
 		my $zcat = '';

--- a/modules/tophat.cfmod.pl
+++ b/modules/tophat.cfmod.pl
@@ -121,6 +121,7 @@ if($se_files && scalar(@$se_files) > 0){
 		$output_dir =~ s/.fastq$//;
 		$output_dir =~ s/_[1-4]$//;
 		$output_dir =~ s/_R[1-4]//;
+		$output_dir .= "_".$cf{config}{genome};
 		$output_dir .= '_tophat';
 
 		my $output_fn = $output_dir."/accepted_hits.bam";
@@ -175,6 +176,7 @@ if($pe_files && scalar(@$pe_files) > 0){
 			$output_dir =~ s/.fastq$//;
 			$output_dir =~ s/_[1-4]$//;
 			$output_dir =~ s/_R[1-4]//;
+			$output_dir .= "_".$cf{config}{genome};
 			$output_dir .= '_tophat';
 
 			my $output_fn = $output_dir."/accepted_hits.bam";


### PR DESCRIPTION
These patches change the way we generate output filenames for mapped data.  They do two things:

1) They clean up the bam names by removing the fq.gz / fastq.gz from the end of the filenames.  Leaving these in place ends up generating very long filenames with no obvious benefit

2) The output filenames now include the name of the genome specified in the command options - this makes it much easier to deal with these downstream - especially where the same data might have been mapped to multiple genomes.

Can you have a look at these and see if you can see any problems with doing things this way.  If this is OK then I'll work my way through the other mapping modules and apply similar patches.