### PR TITLE
Allow genomes.d to be used for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /genomes.config
 *.pyc
 .DS_Store
+/genomes.d/*config

--- a/genomes.d/example.config.template
+++ b/genomes.d/example.config.template
@@ -1,0 +1,14 @@
+/*
+Clusterflow Genomes
+-------------------
+
+The genomes.d directory can be used to create genome configuration files
+with the same structure as the main genomes.config file.  These files
+will be treated as an extension of the main genomes.config file, so you can
+put multiple files in this directory (eg one per species or assembly) if 
+you find this makes it easier to manage your genomes.
+
+Files in this directory can have any name, but must end with .config otherwise
+they will be ignored.
+
+*/

--- a/source/CF/Constants.pm
+++ b/source/CF/Constants.pm
@@ -208,7 +208,7 @@ sub parse_genomes_file {
 
     # Read genomes config variables in. Do in order so that local prefs overwrite.
 
-    my @genome_files = ("$FindBin::Bin/genomes.config", "$homedir/.clusterflow/genomes.config", './genomes.config');
+    my @genome_files = ("$FindBin::Bin/genomes.config",glob("$FindBin::Bin/genomes.d/*config"),"$homedir/.clusterflow/genomes.config",glob("$homedir/.clusterflow/genomes.d/*config"), './genomes.config');
     foreach my $genome_file (@genome_files){
         if(-e $genome_file){
             open (GCONFIG, $genome_file) or die "Can't read $genome_file: $!";
@@ -267,7 +267,7 @@ sub list_clusterflow_genomes {
 
     my $returnstring = "";
 
-    my @config_files = ("$FindBin::Bin/genomes.config", "$homedir/.clusterflow/genomes.config", './genomes.config');
+    my @config_files = ("$FindBin::Bin/genomes.config","$FindBin::Bin/genomes.d/","$homedir/.clusterflow/genomes.config","$homedir/.clusterflow/genomes.d/",'./genomes.config');
 
     foreach my $config_file (@config_files){
 
@@ -277,7 +277,7 @@ sub list_clusterflow_genomes {
         my %conf_lines;
         foreach my $ref_type ( keys %REFERENCES){
             foreach my $genome_key ( keys %{$REFERENCES{$ref_type}}){
-                if(defined($REFERENCES{$ref_type}{$genome_key}{'config_file'}) && $REFERENCES{$ref_type}{$genome_key}{'config_file'} eq $config_file){
+                if(defined($REFERENCES{$ref_type}{$genome_key}{'config_file'}) && index($REFERENCES{$ref_type}{$genome_key}{'config_file'},$config_file)==0){
                     my $t_species = defined($REFERENCES{$ref_type}{$genome_key}{'species'}) ? substr($REFERENCES{$ref_type}{$genome_key}{'species'}, 0, 24) : (" " x 24);
                     my $t_assembly = defined($REFERENCES{$ref_type}{$genome_key}{'species'}) ? substr($REFERENCES{$ref_type}{$genome_key}{'assembly'}, 0, 14) : (" " x 14);
                     my $t_path = defined($REFERENCES{$ref_type}{$genome_key}{'species'}) ? $REFERENCES{$ref_type}{$genome_key}{'path'} : '';


### PR DESCRIPTION
These patches allow genome annotation information to be stored in the `genomes.d` folder in multiple files rather than always being centralised in `genomes.config`.  This should make it easier to scale across large numbers of genomes where a single conf file gets a bit big.

I've updated the code which reads the config info and the code which prints the output for `--genomes`.  I couldn't see anything else which this might break, but shout if you know of anywhere else this might be fragile.